### PR TITLE
Randomize Sleep Time for Scraping

### DIFF
--- a/src/api/api.controller.ts
+++ b/src/api/api.controller.ts
@@ -27,7 +27,7 @@ export class ApiController {
   constructor(
     private apiService: ApiService,
     private readonly csvParser: CsvParser,
-  ) { }
+  ) {}
 
   @Get('/')
   findByKeyword(@Query() query: QuerySearchResult, @Request() req) {

--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -9,7 +9,7 @@ export class ApiService {
   constructor(
     private primsaService: PrismaService,
     private bullservice: BullService,
-  ) { }
+  ) {}
 
   findById(id: number) {
     return this.primsaService.search_results.findFirst({

--- a/src/bull/bull.service.ts
+++ b/src/bull/bull.service.ts
@@ -7,7 +7,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { BullQueueService } from './bull-queue.service';
 import { Logger } from '@nestjs/common';
 
-const MaximumDelaySec = 5;
+const MAXIMUM_DELAY_IN_SECONDS = 5;
 
 @Injectable()
 export class BullService {
@@ -23,7 +23,7 @@ export class BullService {
 
   async addJob(data: Record<string, any>): Promise<Job> {
     return this.queue.add('scrape-data', data, {
-      delay: Math.floor(Math.random() * MaximumDelaySec) + 1,
+      delay: Math.floor(Math.random() * MAXIMUM_DELAY_IN_SECONDS) + 1,
     });
   }
 

--- a/src/bull/bull.service.ts
+++ b/src/bull/bull.service.ts
@@ -23,6 +23,12 @@ export class BullService {
     return this.queue.add('scrape-data', data);
   }
 
+  async sleepAtRandomInterval() {
+    const randomDelay = Math.floor(Math.random() * 5000) + 1000;
+    this.logger.log(`sleep for ${randomDelay / 1000} seconds`);
+    await new Promise((resolve) => setTimeout(resolve, randomDelay));
+  }
+
   async processJobs(): Promise<void> {
     new Worker('scrape-search-result', async (job) => {
       const { keyword, user_id } = job.data;
@@ -33,11 +39,10 @@ export class BullService {
       if (!keywordData) {
         const raw_html = await this.crawlerService.getSearchResultData(keyword);
         const formattedData = this.crawlerService.formatData(raw_html);
-
+        await this.sleepAtRandomInterval();
         await this.prismaService.search_results.create({
           data: { ...formattedData, keyword, user_id },
         });
-        await new Promise((resolve) => setTimeout(resolve, 2000));
         this.logger.log(`finished processing ${keyword}`);
       } else {
         this.logger.log(`${keyword} already existed`);


### PR DESCRIPTION
**Description**

This pull request aims to enhance [our web scraping process](https://github.com/nainglinaung/scraper-test/issues/3) by introducing random sleep times when making requests to Google. Randomized sleep times can help mitigate potential rate-limiting or IP blocking issues and make our scraping process more robust.

**Changes Made**

- update sleep duration to randomly generate within a predefined range to simulate more natural user behavior.

**Checklist**

- [x] I have tested the changes thoroughly.
- [x] The code has been reviewed for any potential issues or concerns.
- [x] The randomized sleep time range is configured appropriately.
- [x] I have run the code linter and resolved any issues.
