### PR TITLE
chore: improve async processing

### DIFF
--- a/prisma/migrations/20231108153949_alter_keyword_to_sync/migration.sql
+++ b/prisma/migrations/20231108153949_alter_keyword_to_sync/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `keyword_status` to the `search_results` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "keyword_status" AS ENUM ('inprogress', 'done');
+
+-- AlterTable
+ALTER TABLE "search_results" ADD COLUMN     "keyword_status" "keyword_status" NOT NULL;

--- a/prisma/migrations/20231108154954_add_default_value_for_enum/migration.sql
+++ b/prisma/migrations/20231108154954_add_default_value_for_enum/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The values [inprogress] on the enum `keyword_status` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "keyword_status_new" AS ENUM ('in-progress', 'done');
+ALTER TABLE "search_results" ALTER COLUMN "keyword_status" TYPE "keyword_status_new" USING ("keyword_status"::text::"keyword_status_new");
+ALTER TYPE "keyword_status" RENAME TO "keyword_status_old";
+ALTER TYPE "keyword_status_new" RENAME TO "keyword_status";
+DROP TYPE "keyword_status_old";
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "search_results" ALTER COLUMN "keyword_status" SET DEFAULT 'in-progress';

--- a/prisma/migrations/20231108161017_set_optionals_to_fields/migration.sql
+++ b/prisma/migrations/20231108161017_set_optionals_to_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "search_results" ALTER COLUMN "adswords_count" DROP NOT NULL,
+ALTER COLUMN "raw_html" DROP NOT NULL;

--- a/prisma/migrations/20231109070614_change_name_to_scrape_status/migration.sql
+++ b/prisma/migrations/20231109070614_change_name_to_scrape_status/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `keyword_status` on the `search_results` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "scraping_status" AS ENUM ('in-progress', 'failed', 'done');
+
+-- AlterTable
+ALTER TABLE "search_results" DROP COLUMN "keyword_status",
+ADD COLUMN     "scraping_status" "scraping_status" NOT NULL DEFAULT 'in-progress';
+
+-- DropEnum
+DROP TYPE "keyword_status";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,13 +8,20 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+
+enum keyword_status {
+  Inprogress @map("in-progress")
+  Done @map("done")
+}
+
 model search_results {
   id                              Int      @id @default(autoincrement())
-  adswords_count                  Int
+  adswords_count                  Int?     
   keyword                         String
+  keyword_status                  keyword_status @default(Inprogress)
   link_count                      Int?
   total_search_result_for_keyword String?
-  raw_html                        String
+  raw_html                        String?
   user_id                         Int
   user                            User     @relation(fields: [user_id], references: [id])
   createdAt                       DateTime @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,9 @@ datasource db {
 }
 
 
-enum keyword_status {
+enum scraping_status                   {
   Inprogress @map("in-progress")
+  Failed  @map("failed")
   Done @map("done")
 }
 
@@ -18,7 +19,7 @@ model search_results {
   id                              Int      @id @default(autoincrement())
   adswords_count                  Int?     
   keyword                         String
-  keyword_status                  keyword_status @default(Inprogress)
+  scraping_status                 scraping_status @default(Inprogress)
   link_count                      Int?
   total_search_result_for_keyword String?
   raw_html                        String?

--- a/src/api/api.controller.ts
+++ b/src/api/api.controller.ts
@@ -59,12 +59,15 @@ export class ApiController {
     const stream = createReadStream(file.path);
     const entities = await this.csvParser.parse(stream, CSVEntity);
 
-    for (const data of entities.list) {
-      await this.apiService.crawl({
-        keyword: data.keyword,
+    const mapData = entities.list.map(({ keyword }) => {
+      return {
+        keyword,
         user_id: req.user.id,
-      });
-    }
+      };
+    });
+    const records = await this.apiService.batchCreate(mapData);
+
+    await Promise.all(records.map((data) => this.apiService.crawl(data)));
 
     return { status: 'success' };
   }

--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -9,7 +9,7 @@ export class ApiService {
   constructor(
     private primsaService: PrismaService,
     private bullservice: BullService,
-  ) { }
+  ) {}
 
   findById(id: number) {
     return this.primsaService.search_results.findFirst({
@@ -39,9 +39,17 @@ export class ApiService {
     return this.bullservice.addJob(data);
   }
 
-  create(createSearchResult): Promise<SearchResult> {
+  create(data): Promise<SearchResult> {
     return this.primsaService.search_results.create({
-      data: createSearchResult,
+      data,
     });
+  }
+
+  batchCreate(data) {
+    return this.primsaService.$transaction(
+      data.map((record) =>
+        this.primsaService.search_results.create({ data: record }),
+      ),
+    );
   }
 }

--- a/src/bull/bull.service.ts
+++ b/src/bull/bull.service.ts
@@ -34,7 +34,7 @@ export class BullService {
         where: {
           id,
         },
-        data: { ...formattedData },
+        data: { ...formattedData, keyword_status: 'Done' },
       });
 
       await new Promise((resolve) => setTimeout(resolve, 3000));


### PR DESCRIPTION
**Description**

Rather than using a queue for immediate processing, keywords are initially inserted into the database in batches. Subsequently, they are placed in a queue for data scraping, followed by the necessary updates.

**Changes Made**

- I have updated the Prisma schema to allow for keyword status and made other fields optional.
- Instead of placing data into a queue, it is now inserted into a table and then sent to the queue.
- In the worker, the status flag is updated instead of inserting data.

**Check List**

- [x] I have tested the changes thoroughly.
- [x] I have run the code linter and resolved any issues.
